### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/nyurik/dup-indexer/compare/v0.4.3...v0.4.4) - 2025-06-11
+
+### Other
+
+- use release-plz token in dependabot ci
+
 ## [0.4.3](https://github.com/nyurik/dup-indexer/compare/v0.4.2...v0.4.3) - 2025-06-08
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dup-indexer"
-version = "0.4.3"
+version = "0.4.4"
 description = "Create a non-duplicated index from Strings, static str, Vec, or Box values"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/dup-indexer"


### PR DESCRIPTION



## 🤖 New release

* `dup-indexer`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.4](https://github.com/nyurik/dup-indexer/compare/v0.4.3...v0.4.4) - 2025-06-11

### Other

- use release-plz token in dependabot ci
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).