### PR TITLE
chore: release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/nyurik/dup-indexer/compare/v0.4.4...v0.4.5) - 2025-12-01
+
+### Other
+
+- add .editorconfig
+- Bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#24](https://github.com/nyurik/dup-indexer/pull/24))
+- minor justfile adjustments
+- minor justfile adjustments
+
 ## [0.4.4](https://github.com/nyurik/dup-indexer/compare/v0.4.3...v0.4.4) - 2025-10-01
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/nyurik/dup-indexer/compare/v0.4.4...v0.4.5) - 2026-06-18
+
+### Other
+
+- [pre-commit.ci] pre-commit autoupdate ([#27](https://github.com/nyurik/dup-indexer/pull/27))
+- .editorconfig, coverage and MSRV fixes ([#26](https://github.com/nyurik/dup-indexer/pull/26))
+- add .editorconfig
+- Bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#24](https://github.com/nyurik/dup-indexer/pull/24))
+- minor justfile adjustments
+- minor justfile adjustments
+
 ## [0.4.4](https://github.com/nyurik/dup-indexer/compare/v0.4.3...v0.4.4) - 2025-10-01
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dup-indexer"
-version = "0.4.4"
+version = "0.4.5"
 description = "Create a non-duplicated index from Strings, static str, Vec, or Box values"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/dup-indexer"


### PR DESCRIPTION



## 🤖 New release

* `dup-indexer`: 0.4.4 -> 0.4.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.5](https://github.com/nyurik/dup-indexer/compare/v0.4.4...v0.4.5) - 2026-06-18

### Other

- [pre-commit.ci] pre-commit autoupdate ([#27](https://github.com/nyurik/dup-indexer/pull/27))
- .editorconfig, coverage and MSRV fixes ([#26](https://github.com/nyurik/dup-indexer/pull/26))
- add .editorconfig
- Bump actions/checkout from 5 to 6 in the all-actions-version-updates group ([#24](https://github.com/nyurik/dup-indexer/pull/24))
- minor justfile adjustments
- minor justfile adjustments
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).