### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- [**breaking**] use foldhash by default ([#30](https://github.com/nyurik/dup-indexer/pull/30))
+- [**breaking**] use significantly faster foldhash by default ([#30](https://github.com/nyurik/dup-indexer/pull/30))
 
 ## [0.4.5](https://github.com/nyurik/dup-indexer/compare/v0.4.4...v0.4.5) - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/nyurik/dup-indexer/compare/v0.4.5...v0.5.0) - 2026-06-18
+
+### Other
+
+- [**breaking**] use foldhash by default ([#30](https://github.com/nyurik/dup-indexer/pull/30))
+
 ## [0.4.5](https://github.com/nyurik/dup-indexer/compare/v0.4.4...v0.4.5) - 2026-06-18
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dup-indexer"
-version = "0.4.5"
+version = "0.5.0"
 description = "Create a non-duplicated index from Strings, static str, Vec, or Box values"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/dup-indexer"


### PR DESCRIPTION



## 🤖 New release

* `dup-indexer`: 0.4.5 -> 0.5.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/nyurik/dup-indexer/compare/v0.4.5...v0.5.0) - 2026-06-18

### Other

- [**breaking**] use foldhash by default ([#30](https://github.com/nyurik/dup-indexer/pull/30))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).