### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/nyurik/dup-indexer/compare/v0.5.0...v0.5.1) - 2026-06-22
+
+### Other
+
+- update .gitignore
+- format justfile
+- *(deps)* bump actions/checkout from 6 to 7 in the all-actions-version-updates group ([#33](https://github.com/nyurik/dup-indexer/pull/33))
+- fmt toml
+- pre-commit bump
+
 ## [0.5.0](https://github.com/nyurik/dup-indexer/compare/v0.4.5...v0.5.0) - 2026-06-18
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dup-indexer"
-version = "0.5.0"
+version = "0.5.1"
 description = "Create a non-duplicated index from Strings, static str, Vec, or Box values"
 authors = ["Yuri Astrakhan <YuriAstrakhan@gmail.com>"]
 repository = "https://github.com/nyurik/dup-indexer"


### PR DESCRIPTION



## 🤖 New release

* `dup-indexer`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/nyurik/dup-indexer/compare/v0.5.0...v0.5.1) - 2026-06-22

### Other

- update .gitignore
- format justfile
- *(deps)* bump actions/checkout from 6 to 7 in the all-actions-version-updates group ([#33](https://github.com/nyurik/dup-indexer/pull/33))
- fmt toml
- pre-commit bump
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).